### PR TITLE
feat/integrating-with-git-hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "iamcommitted"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iamcommitted"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 description = "A command line application that generates Git commit messages based on the Git diff."
 authors = ["Glyn Darkin"]

--- a/hooks/prepare-commit-msg.sh
+++ b/hooks/prepare-commit-msg.sh
@@ -7,20 +7,17 @@
 # 2. The type of commit (e.g., message, template, merge, squash, commit).
 # 3. The commit SHA-1 if -c, -C, or --fixup is given.
 
-# Assuming the iamcommitted binary is in the target/release directory
-# and the hook is run from the root of the repository.
+# Assuming the iamcommitted binary is installed in /usr/local/bin
 # Adjust the path to the binary if necessary.
-EXECUTABLE_PATH="./target/release/iamcommitted"
+EXECUTABLE_PATH="/usr/local/bin/iamcommitted"
 
-# Check if the executable exists
+# Check if the executable exists and is executable
 if [ ! -x "$EXECUTABLE_PATH" ]; then
-  # Fallback to debug if release is not found
-  EXECUTABLE_PATH="./target/debug/iamcommitted"
-  if [ ! -x "$EXECUTABLE_PATH" ]; then
-    echo "Error: iamcommitted executable not found or not executable at $EXECUTABLE_PATH or ./target/release/iamcommitted."
-    echo "Please build the project using 'cargo build' or 'cargo build --release'."
-    exit 1
-  fi
+  echo "Error: iamcommitted executable not found or not executable at $EXECUTABLE_PATH."
+  echo "Please ensure 'iamcommitted' is built and installed to /usr/local/bin."
+  echo "You can build with 'cargo build --release' and then copy 'target/release/iamcommitted' to '/usr/local/bin/',"
+  echo "or use 'cargo install --path .' if your cargo bin directory is in your PATH and then symlink/copy from there."
+  exit 1
 fi
 
 # Pass all arguments to the iamcommitted binary

--- a/hooks/prepare-commit-msg.sh
+++ b/hooks/prepare-commit-msg.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Git hook to prepare commit message using i-am-committed
+#
+# This hook is called by 'git commit' with up to three arguments:
+# 1. The name of the file that contains the commit log message.
+# 2. The type of commit (e.g., message, template, merge, squash, commit).
+# 3. The commit SHA-1 if -c, -C, or --fixup is given.
+
+# Assuming the iamcommitted binary is in the target/release directory
+# and the hook is run from the root of the repository.
+# Adjust the path to the binary if necessary.
+EXECUTABLE_PATH="./target/release/iamcommitted"
+
+# Check if the executable exists
+if [ ! -x "$EXECUTABLE_PATH" ]; then
+  # Fallback to debug if release is not found
+  EXECUTABLE_PATH="./target/debug/iamcommitted"
+  if [ ! -x "$EXECUTABLE_PATH" ]; then
+    echo "Error: iamcommitted executable not found or not executable at $EXECUTABLE_PATH or ./target/release/iamcommitted."
+    echo "Please build the project using 'cargo build' or 'cargo build --release'."
+    exit 1
+  fi
+fi
+
+# Pass all arguments to the iamcommitted binary
+# The binary should be designed to handle these arguments
+# and write the generated message to the file specified by $1.
+"$EXECUTABLE_PATH" prepare-commit-msg "$@"
+
+# Exit with the status of the iamcommitted binary
+exit $?

--- a/readme.md
+++ b/readme.md
@@ -50,15 +50,27 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Build and Install
 
-To build and install the command line tool, use the following command:
+To build the command line tool:
 
 ```sh
-cargo install --path .
+cargo build --release
 ```
+
+This will create the executable at `target/release/iamcommitted`.
+
+To make it accessible system-wide (and for the Git hook), you can copy it to a directory in your PATH, such as `/usr/local/bin`:
+
+```sh
+sudo cp target/release/iamcommitted /usr/local/bin/
+```
+
+Alternatively, `cargo install --path .` will install it to your Cargo binary directory (e.g., `~/.cargo/bin/`). If you use this method, ensure `~/.cargo/bin/` is in your system's PATH and the hook script is adjusted accordingly if you don't symlink/copy to `/usr/local/bin`. For simplicity, the provided hook script assumes `/usr/local/bin/iamcommitted`.
 
 ### Running the Application from command line
 
-The CLI currently uses OpenAIs API. So you will need to get your [own API key](https://platform.openai.com/) and set it as an environment variable, or as part of your vscode launch.json
+If you've installed `iamcommitted` to `/usr/local/bin` or another directory in your PATH, you can run it directly.
+
+The CLI currently uses OpenAI's API. So you will need to get your [own API key](https://platform.openai.com/) and set it as an environment variable, or as part of your vscode launch.json
 
 ```sh
 export OPENAI_API_KEY=<key>
@@ -91,23 +103,21 @@ This commit removes the unused import of `CommitType` from the `commit_formatter
 
 #### Installation
 
-1.  **Build the binary:**
-    Ensure you have built the `i-am-committed` executable. You can do this with:
-    ```sh
-    cargo build
-    ```
-    Or for a release version:
+1.  **Build and Install the `iamcommitted` binary:**
+    Ensure you have built the `iamcommitted` executable and placed it in `/usr/local/bin/`.
     ```sh
     cargo build --release
+    sudo cp target/release/iamcommitted /usr/local/bin/
     ```
-    The hook script (`hooks/prepare-commit-msg.sh`) expects the binary to be in `target/debug/i-am-committed` or `target/release/i-am-committed`.
+    Make sure `/usr/local/bin/iamcommitted` is executable. The `cp` command should preserve permissions, but you can verify with `ls -l /usr/local/bin/iamcommitted`.
+    The hook script (`hooks/prepare-commit-msg.sh`) now expects the binary to be at `/usr/local/bin/iamcommitted`.
 
 2.  **Make the hook script executable:**
     ```sh
     chmod +x hooks/prepare-commit-msg.sh
     ```
 
-3.  **Install the hook:**
+3.  **Install the Git hook script:**
     Copy or symlink the provided `hooks/prepare-commit-msg.sh` script to your local repository's `.git/hooks/` directory.
 
     To copy:

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ Another interesting aspect of this project is that I am using it to generate my 
     - [Install Rust \& Cargo](#install-rust--cargo)
     - [Build and Install](#build-and-install)
     - [Running the Application from command line](#running-the-application-from-command-line)
+    - [Using as a `prepare-commit-msg` Hook](#using-as-a-prepare-commit-msg-hook)
   - [Unit Tests](#unit-tests)
     - [References](#references)
 
@@ -83,6 +84,51 @@ refactor(commit_formatter): remove unused import of CommitType
 
 This commit removes the unused import of `CommitType` from the `commit_formatter` module, helping to clean up the code and improve readability.
 ```
+
+### Using as a `prepare-commit-msg` Hook
+
+`i-am-committed` can also be used as a Git `prepare-commit-msg` hook to automatically generate a commit message before your editor opens.
+
+#### Installation
+
+1.  **Build the binary:**
+    Ensure you have built the `i-am-committed` executable. You can do this with:
+    ```sh
+    cargo build
+    ```
+    Or for a release version:
+    ```sh
+    cargo build --release
+    ```
+    The hook script (`hooks/prepare-commit-msg.sh`) expects the binary to be in `target/debug/i-am-committed` or `target/release/i-am-committed`.
+
+2.  **Make the hook script executable:**
+    ```sh
+    chmod +x hooks/prepare-commit-msg.sh
+    ```
+
+3.  **Install the hook:**
+    Copy or symlink the provided `hooks/prepare-commit-msg.sh` script to your local repository's `.git/hooks/` directory.
+
+    To copy:
+    ```sh
+    cp hooks/prepare-commit-msg.sh .git/hooks/prepare-commit-msg
+    ```
+
+    To symlink (recommended, so updates to the script in the repository are automatically reflected):
+    ```sh
+    ln -s -f ../../hooks/prepare-commit-msg.sh .git/hooks/prepare-commit-msg
+    ```
+    *(Ensure you run this command from the root of your repository.)*
+
+#### Usage
+
+Once installed, the hook will automatically run when you execute `git commit`.
+
+- If you run `git commit` without `-m` or a template, `i-am-committed` will generate a message and write it to the commit message file. Your editor will then open with this pre-filled message.
+- If you use `git commit -m "Your message"` or have a commit template configured, `i-am-committed` will not overwrite your message or template.
+
+You still need to have your `OPENAI_API_KEY` environment variable set for the hook to function correctly.
 
 ## Unit Tests
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use std::fs;
 use std::io::Write;
 use std::{env, io, process::Command};
 use colored::Colorize;
@@ -28,132 +29,216 @@ mod commit_formatter;
 mod git;
 mod ai;
 
-use commit_formatter::CommitFormatter;
-use git::GitClient;
-use ai::AIClient;
+use crate::commit_formatter::CommitFormatter;
+use crate::git::GitClient;
+use crate::ai::AIClient;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
-struct Cli {}
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Prepares the commit message (for git prepare-commit-msg hook)
+    PrepareCommitMsg {
+        /// Path to the commit message file
+        #[arg(index = 1)]
+        commit_msg_file_path: String,
+
+        /// Source of the commit message (e.g., message, template, merge, squash, commit)
+        #[arg(index = 2, required = false)]
+        commit_source: Option<String>,
+
+        /// Commit SHA-1 (if applicable, e.g., for amends)
+        #[arg(index = 3, required = false)]
+        commit_sha1: Option<String>,
+    },
+}
+
+async fn generate_formatted_commit_message(
+    git_client: &GitClient,
+    ai_client: &AIClient,
+) -> Result<String, Box<dyn std::error::Error>> {
+    // Get the full diff for AI processing
+    let diff = git_client.get_staged_changes()?;
+    info!("Retrieved diff for AI processing (first 500 chars):\n{}", diff.chars().take(500).collect::<String>());
+
+
+    if diff.trim().is_empty() {
+        let staged_files_list = git_client.get_staged_files()?;
+        if staged_files_list.trim().is_empty() {
+            warn!("Diff is empty and no staged files. AI will process an empty context.");
+        } else {
+            warn!("Diff is empty, but staged files are present (e.g. mode changes, new empty files). AI will process based on file list if prompt supports it.");
+        }
+    }
+    
+    // Generate commit message using AI
+    let raw_message = ai_client.generate_commit_message(&diff).await?;
+    info!("Raw AI-generated message: {}", raw_message);
+    
+    // Format the commit message
+    let formatter = CommitFormatter::new(raw_message.clone());
+    let formatted_commit = formatter.format();
+    let final_message = formatted_commit.to_string();
+    info!("Formatted commit message: {}", final_message);
+
+    Ok(final_message)
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     setup_logging()?;
-    println!(
-        "{}",
-        r#"
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Some(Commands::PrepareCommitMsg { commit_msg_file_path, commit_source, commit_sha1 }) => {
+            info!("Running in prepare-commit-msg hook mode.");
+            info!("Commit message file: {}", commit_msg_file_path);
+            if let Some(source) = &commit_source {
+                info!("Commit source: {}", source);
+                // If the user is providing a message via -m or -F, or using a template,
+                // we should not overwrite it with an AI-generated one.
+                if source == "message" || source == "template" {
+                    info!("Commit source is '{}', skipping AI message generation.", source);
+                    return Ok(());
+                }
+            }
+            if let Some(sha1) = &commit_sha1 {
+                info!("Commit SHA1: {}", sha1);
+            }
+
+            let api_key = env::var("OPENAI_API_KEY").map_err(|_| {
+                "Error: OPENAI_API_KEY environment variable is not set for prepare-commit-msg hook."
+            })?;
+            let git_client = GitClient::new();
+            let ai_client = AIClient::new(api_key)?;
+
+            // Check for staged changes. Even if none, AI might generate a message for an empty commit if allowed.
+            if !git_client.has_staged_changes()? {
+                warn!("No staged changes detected by git_client.has_staged_changes() in hook mode. Proceeding to generate message based on (likely empty) diff.");
+            }
+
+            match generate_formatted_commit_message(&git_client, &ai_client).await {
+                Ok(commit_message_content) => {
+                    fs::write(&commit_msg_file_path, &commit_message_content)?;
+                    info!("Successfully wrote AI-generated commit message to {}", commit_msg_file_path);
+                }
+                Err(e) => {
+                    eprintln!("Error generating commit message for hook: {}", e);
+                    // Propagate the error to potentially halt the commit process
+                    return Err(e);
+                }
+            }
+            Ok(())
+        }
+        None => {
+            // Interactive mode (original behavior)
+            println!(
+                "{}",
+                r#"
     ____               _____                 _ __  __         __
     /  _/ ___ ___ _    / ___/__  __ _  __ _  (_) /_/ /____ ___/ /
-   _/ /  / _ `/  ' \  / /__/ _ \/  ' \/  ' \/ / __/ __/ -_) _  / 
-  /___/  \_,_/_/_/_/  \___/\___/_/_/_/_/_/_/_/\__/\__/\__/\_,_/  
+   _/ /  / _ `/  ' \  / /__/ _ \/  ' \/  ' \/ / __/ __/ -_) _  /
+  /___/  \_,_/_/_/_/  \___/\___/_/_/_/_/_/_/_/\__/\__/\__/\_,_/
                                                                  
       "#
-        .green()
-    );
-    println!("{}", VERSION);
-    println!("\n{}", "🔍 Analysing Changes...".blue());
-    println!("-----------------------------------------");
+                .green()
+            );
+            println!("{}", VERSION);
+            println!("\n{}", "🔍 Analysing Changes...".blue());
+            println!("-----------------------------------------");
 
-    let api_key = env::var("OPENAI_API_KEY").map_err(|_| {
-        "Error: OPENAI_API_KEY environment variable is not set. Please set this environment variable with your OpenAI API key to use this application."
-    })?;
+            let api_key = env::var("OPENAI_API_KEY").map_err(|_| {
+                "Error: OPENAI_API_KEY environment variable is not set. Please set this environment variable with your OpenAI API key to use this application."
+            })?;
 
-    let git_client = GitClient::new();
-    let ai_client = AIClient::new(api_key)?;
+            let git_client = GitClient::new();
+            let ai_client = AIClient::new(api_key)?;
 
-    if !git_client.has_staged_changes()? {
-        warn!("No staged changes found.");
-        println!("\n{} No staged changes found.", "!".yellow());
-        println!("\n  Please stage your changes using 'git add' before running this command.\n");
-        return Ok(());
-    }
-
-    // Print the staged files
-    println!("📂 Staged Files:");
-    let staged_files = git_client.get_staged_files()?;
-    for file in staged_files.lines() {
-        println!("   - {}", file);
-    }
-    println!("-----------------------------------------");
-
-    // Get the full diff for AI processing
-    let diff = git_client.get_staged_changes()?;
-    
-    // Generate commit message using AI
-    let raw_message = ai_client.generate_commit_message(&diff).await?;
-    
-    // Format the commit message
-    let formatter = CommitFormatter::new(raw_message.clone());
-    let formatted_commit = formatter.format();
-    let commit_message = formatted_commit.to_string();
-
-    println!("\n📝 Suggested Commit Message:");
-    println!("---------------------------------------------------");
-    println!("{}", commit_message);
-    println!("---------------------------------------------------");
-    
-    println!("\nPlease select an option:");
-    println!("[1] Use the suggested message ✅ (default)");
-    // println!("[2] Choose an alternative");
-    println!("[2] Edit the message manually");
-    println!("[3] Cancel");
-
-    print!("\nEnter your choice (1-3): ⌨️  ");
-    io::stdout().flush().unwrap();
-
-    let mut input = String::new();
-    io::stdin().read_line(&mut input).expect("Failed to read line");
-
-    let num_result = input.trim().parse::<u32>();
-
-    if num_result.is_err() {
-        println!("\n{} Please enter a valid number (1-3)\n", "❌".red());
-        return Ok(());
-    }
-
-    let num = num_result.unwrap();
-    let final_message = match num {
-        1 => commit_message,
-        2 => {
-            // Edit commit message using nano
-            use std::fs;
-            use tempfile::NamedTempFile;
-            
-            // Create a temporary file with the commit message
-            let mut temp_file = NamedTempFile::new()?;
-            write!(temp_file, "{}", commit_message)?;
-            temp_file.flush()?;
-            
-            // Open nano to edit the message
-            let status = Command::new("nano")
-                .arg(temp_file.path())
-                .status()
-                .expect("Failed to open nano");
-                
-            if !status.success() {
-                println!("\nFailed to edit commit message");
+            if !git_client.has_staged_changes()? {
+                warn!("No staged changes found.");
+                println!("\n{} No staged changes found.", "!".yellow());
+                println!("\n  Please stage your changes using 'git add' before running this command.\n");
                 return Ok(());
             }
-            
-            // Read back the edited message
-            let edited_message = fs::read_to_string(temp_file.path())?;
-            
-            // Format the edited message
-            let formatter = CommitFormatter::new(edited_message);
-            let formatted_commit = formatter.format();
-            formatted_commit.to_string()
-        }
-        _ => {
-            println!("\nCommit cancelled\n");
-            return Ok(());
-        }
-    };
 
-    // Proceed with commit if a message was selected/edited
-    if num <= 2 {
-        git_client.commit_with_details(&final_message).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+            // Print the staged files
+            println!("📂 Staged Files:");
+            let staged_files = git_client.get_staged_files()?;
+            for file in staged_files.lines() {
+                println!("   - {}", file);
+            }
+            println!("-----------------------------------------");
+
+            let commit_message = generate_formatted_commit_message(&git_client, &ai_client).await?;
+
+            println!("\n📝 Suggested Commit Message:");
+            println!("---------------------------------------------------");
+            println!("{}", commit_message);
+            println!("---------------------------------------------------");
+            
+            println!("\nPlease select an option:");
+            println!("[1] Use the suggested message ✅ (default)");
+            println!("[2] Edit the message manually");
+            println!("[3] Cancel");
+
+            print!("\nEnter your choice (1-3): ⌨️  ");
+            io::stdout().flush().unwrap();
+
+            let mut input = String::new();
+            io::stdin().read_line(&mut input).expect("Failed to read line");
+
+            let num_result = input.trim().parse::<u32>();
+
+            if num_result.is_err() {
+                println!("\n{} Please enter a valid number (1-3)\n", "❌".red());
+                return Ok(());
+            }
+
+            let num = num_result.unwrap();
+            let final_message = match num {
+                1 => commit_message,
+                2 => {
+                    // Edit commit message using nano
+                    // Note: std::fs is already imported at the top level
+                    use tempfile::NamedTempFile; // Keep this local as it's specific to this block
+                    
+                    let mut temp_file = NamedTempFile::new()?;
+                    write!(temp_file, "{}", commit_message)?;
+                    temp_file.flush()?;
+                    
+                    let status = Command::new("nano")
+                        .arg(temp_file.path())
+                        .status()
+                        .expect("Failed to open nano");
+                        
+                    if !status.success() {
+                        println!("\nFailed to edit commit message using nano");
+                        return Ok(());
+                    }
+                    
+                    let edited_message = fs::read_to_string(temp_file.path())?;
+                    
+                    let formatter = CommitFormatter::new(edited_message);
+                    let formatted_commit = formatter.format();
+                    formatted_commit.to_string()
+                }
+                _ => {
+                    println!("\nCommit cancelled\n");
+                    return Ok(());
+                }
+            };
+
+            if num <= 2 { // Only commit if option 1 or 2 was chosen
+                git_client.commit_with_details(&final_message).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+            }
+            Ok(())
+        }
     }
-
-    Ok(())
 }


### PR DESCRIPTION
This PR introduces support for i-am-committed to function as a Git prepare-commit-msg hook. This allows the tool to automatically generate a commit message and populate it before the commit message editor opens, streamlining the commit process.

Key Changes:

New Hook Script (hooks/prepare-commit-msg.sh):

A new shell script has been added at [hooks/prepare-commit-msg.sh](vscode-webview://0jbk2ref172v0h6hiqdvbir80961fe4rdh1t5jtlsubjae3nhdle/hooks/prepare-commit-msg.sh:1).
This script is designed to be used as the prepare-commit-msg Git hook.
It calls the main iamcommitted binary, passing the necessary arguments provided by Git (commit message file path, commit source, etc.).
The script now expects the iamcommitted executable to be located at /usr/local/bin/iamcommitted.
Application Logic (src/main.rs):

The main application logic in [src/main.rs](vscode-webview://0jbk2ref172v0h6hiqdvbir80961fe4rdh1t5jtlsubjae3nhdle/src/main.rs) has been updated to handle a new prepare-commit-msg subcommand.
When invoked via the hook, it generates the commit message based on staged changes and writes it directly to the commit message file specified by Git.
It intelligently skips message generation if the commit is initiated with git commit -m "..." or a commit template is being used, to avoid overwriting user-provided messages.
The core message generation logic has been refactored into a reusable function.
Documentation (README.md):

The [README.md](vscode-webview://0jbk2ref172v0h6hiqdvbir80961fe4rdh1t5jtlsubjae3nhdle/README.md) has been significantly updated to include:
Instructions for building the iamcommitted binary (cargo build --release).
Steps to install the binary to /usr/local/bin/iamcommitted.
Detailed instructions on how to set up the prepare-commit-msg hook by copying or symlinking the new script to the local repository's .git/hooks/ directory.
Version Bump (Cargo.toml):

The project version in [Cargo.toml](cargo.toml:3) has been incremented from 0.1.0-alpha to 0.2.0-alpha to reflect this new feature.
How it Works:

When git commit is run, Git executes the .git/hooks/prepare-commit-msg script (if present).
Our script calls /usr/local/bin/iamcommitted prepare-commit-msg <args...>.
The iamcommitted application generates the commit message using the AI service based on staged changes.
The generated message is written to the file Git provides (e.g., .git/COMMIT_EDITMSG).
The user's commit editor then opens with the AI-generated message pre-filled.
This feature aims to make it even easier to maintain consistent and high-quality commit messages.

Please review the changes.

Thanks!